### PR TITLE
Fixed the library to support wide options

### DIFF
--- a/TouchScreen.cpp
+++ b/TouchScreen.cpp
@@ -57,18 +57,23 @@ TSPoint TouchScreen::getPoint(void) {
 
   pinMode(_yp, INPUT);
   pinMode(_ym, INPUT);
-  
+  #if defined(__arm__)
+	digitalWrite(_yp, LOW);
+	digitalWrite(_ym, LOW);
+  #else
   *portOutputRegister(yp_port) &= ~yp_pin;
   *portOutputRegister(ym_port) &= ~ym_pin;
-  //digitalWrite(_yp, LOW);
-  //digitalWrite(_ym, LOW);
+  #endif
    
-  pinMode(_xp, OUTPUT);
-  pinMode(_xm, OUTPUT);
-  //digitalWrite(_xp, HIGH);
-  //digitalWrite(_xm, LOW);
-  *portOutputRegister(xp_port) |= xp_pin;
-  *portOutputRegister(xm_port) &= ~xm_pin;
+	pinMode(_xp, OUTPUT);
+	pinMode(_xm, OUTPUT);
+  #if defined(__arm__)
+	digitalWrite(_xp, HIGH);
+	digitalWrite(_xm, LOW);
+  #else
+	*portOutputRegister(xp_port) |= xp_pin;
+	*portOutputRegister(xm_port) &= ~xm_pin;
+   #endif
    
    for (i=0; i<NUMSAMPLES; i++) {
      samples[i] = analogRead(_yp);
@@ -83,12 +88,18 @@ TSPoint TouchScreen::getPoint(void) {
 
    pinMode(_xp, INPUT);
    pinMode(_xm, INPUT);
-   *portOutputRegister(xp_port) &= ~xp_pin;
-   //digitalWrite(_xp, LOW);
+   #if defined(__arm__)
+		digitalWrite(_xp, LOW);
+   #else
+		*portOutputRegister(xp_port) &= ~xp_pin;
+   #endif
    
    pinMode(_yp, OUTPUT);
-   *portOutputRegister(yp_port) |= yp_pin;
-   //digitalWrite(_yp, HIGH);
+	#if defined(__arm__)
+		digitalWrite(_yp, HIGH);
+	#else
+		*portOutputRegister(yp_port) |= yp_pin;
+	#endif
    pinMode(_ym, OUTPUT);
   
    for (i=0; i<NUMSAMPLES; i++) {
@@ -104,18 +115,21 @@ TSPoint TouchScreen::getPoint(void) {
 
    y = (1023-samples[NUMSAMPLES/2]);
 
-   // Set X+ to ground
+   
    pinMode(_xp, OUTPUT);
-   *portOutputRegister(xp_port) &= ~xp_pin;
-   //digitalWrite(_xp, LOW);
-  
-   // Set Y- to VCC
-   *portOutputRegister(ym_port) |= ym_pin;
-   //digitalWrite(_ym, HIGH); 
-  
-   // Hi-Z X- and Y+
-   *portOutputRegister(yp_port) &= ~yp_pin;
-   //digitalWrite(_yp, LOW);
+   #if defined(__arm__)
+		digitalWrite(_xp, LOW);
+		digitalWrite(_ym, HIGH);
+		digitalWrite(_yp, LOW);
+	#else
+		// Set X+ to ground
+		*portOutputRegister(xp_port) &= ~xp_pin;
+		// Set Y- to VCC
+		*portOutputRegister(ym_port) |= ym_pin;
+		// Hi-Z X- and Y+
+		*portOutputRegister(yp_port) &= ~yp_pin;
+	#endif
+	
    pinMode(_yp, INPUT);
   
    uint16_t z1 = analogRead(_xm); 
@@ -152,17 +166,20 @@ TouchScreen::TouchScreen(uint8_t xp, uint8_t yp, uint8_t xm, uint8_t ym) {
   _ym = ym;
   _xp = xp;
   _rxplate = 0;
-  
-  //Added these to here for speed up the point detection
-  xp_port = digitalPinToPort(_xp);
-  yp_port = digitalPinToPort(_yp);
-  xm_port = digitalPinToPort(_xm);
-  ym_port = digitalPinToPort(_ym);
+	#if defined(__arm__)
+		//No direct port manipulation on DUE and ARM
+	#else
+		//Added these to here for speed up the point detection
+		xp_port = digitalPinToPort(_xp);
+		yp_port = digitalPinToPort(_yp);
+		xm_port = digitalPinToPort(_xm);
+		ym_port = digitalPinToPort(_ym);
 
-  xp_pin = digitalPinToBitMask(_xp);
-  yp_pin = digitalPinToBitMask(_yp);
-  xm_pin = digitalPinToBitMask(_xm);
-  ym_pin = digitalPinToBitMask(_ym);
+		xp_pin = digitalPinToBitMask(_xp);
+		yp_pin = digitalPinToBitMask(_yp);
+		xm_pin = digitalPinToBitMask(_xm);
+		ym_pin = digitalPinToBitMask(_ym);
+	#endif
   
   pressureThreshhold = 10;
 }
@@ -176,38 +193,48 @@ TouchScreen::TouchScreen(uint8_t xp, uint8_t yp, uint8_t xm, uint8_t ym,
   _xp = xp;
   _rxplate = rxplate;
   
-  //Added these to here for speed up the point detection
-  xp_port = digitalPinToPort(_xp);
-  yp_port = digitalPinToPort(_yp);
-  xm_port = digitalPinToPort(_xm);
-  ym_port = digitalPinToPort(_ym);
-
-  xp_pin = digitalPinToBitMask(_xp);
-  yp_pin = digitalPinToBitMask(_yp);
-  xm_pin = digitalPinToBitMask(_xm);
-  ym_pin = digitalPinToBitMask(_ym);
+	#if defined(__arm__)
+		//No direct port manipulation on DUE and ARM
+	#else
   
+		//Added these to here for speed up the point detection
+		xp_port = digitalPinToPort(_xp);
+		yp_port = digitalPinToPort(_yp);
+		xm_port = digitalPinToPort(_xm);
+		ym_port = digitalPinToPort(_ym);
+
+		xp_pin = digitalPinToBitMask(_xp);
+		yp_pin = digitalPinToBitMask(_yp);
+		xm_pin = digitalPinToBitMask(_xm);
+		ym_pin = digitalPinToBitMask(_ym);
+	#endif
   pressureThreshhold = 10;
 }
 
 uint16_t TouchScreen::readTouchX(void) {
    //Added int to save result
    uint16_t result;
-   
-   pinMode(_yp, INPUT);
-   pinMode(_ym, INPUT);
-   *portOutputRegister(yp_port) &= ~yp_pin;
-   //digitalWrite(_yp, LOW);
-   *portOutputRegister(ym_port) &= ~ym_pin;
-   //digitalWrite(_ym, LOW);
-   
-   pinMode(_xp, OUTPUT);
-   *portOutputRegister(xp_port) |= xp_pin;
-   //digitalWrite(_xp, HIGH);
-   
-   pinMode(_xm, OUTPUT);
-   *portOutputRegister(xm_port) &= ~xm_pin;
-   //digitalWrite(_xm, LOW);
+   #if defined(__arm__)
+		pinMode(_yp, INPUT);
+		pinMode(_ym, INPUT);
+		//digitalWrite(_yp, LOW);
+		//digitalWrite(_ym, LOW);
+		 pinMode(_xp, OUTPUT);
+		 digitalWrite(_xp, HIGH);
+		 pinMode(_xm, OUTPUT);
+		 digitalWrite(_xm, LOW);
+		 digitalWrite(_xm, LOW);
+	#else 
+	
+		pinMode(_yp, INPUT);
+		pinMode(_ym, INPUT);	
+		*portOutputRegister(yp_port) &= ~yp_pin;
+		*portOutputRegister(ym_port) &= ~ym_pin;  
+		pinMode(_xp, OUTPUT);
+		*portOutputRegister(xp_port) |= xp_pin;
+		pinMode(_xm, OUTPUT);
+		*portOutputRegister(xm_port) &= ~xm_pin;
+	#endif
    
    result = 1023-analogRead(_yp);
    
@@ -222,20 +249,26 @@ uint16_t TouchScreen::readTouchY(void) {
 	//Added int to save result
    uint16_t result;
    
-   pinMode(_xp, INPUT);
-   pinMode(_xm, INPUT);
-   *portOutputRegister(xp_port) &= ~xp_pin;
-   //digitalWrite(_xp, LOW);
-   *portOutputRegister(xm_port) &= ~xm_pin;
-   //digitalWrite(_xm, LOW);
-   
-   pinMode(_yp, OUTPUT);
-   *portOutputRegister(yp_port) |= yp_pin;
-   //digitalWrite(_yp, HIGH);
-   pinMode(_ym, OUTPUT);
-   *portOutputRegister(ym_port) &= ~ym_pin;
-   //digitalWrite(_ym, LOW);
-   
+	#if defined(__arm__)
+		pinMode(_xp, INPUT);
+		pinMode(_xm, INPUT);
+		digitalWrite(_xp, LOW);
+		digitalWrite(_xm, LOW);
+		pinMode(_yp, OUTPUT);
+		digitalWrite(_yp, HIGH);
+		pinMode(_ym, OUTPUT);
+		digitalWrite(_ym, LOW);
+	#else
+		pinMode(_xp, INPUT);
+		pinMode(_xm, INPUT);
+		*portOutputRegister(xp_port) &= ~xp_pin;
+		*portOutputRegister(xm_port) &= ~xm_pin;
+		pinMode(_yp, OUTPUT);
+		*portOutputRegister(yp_port) |= yp_pin;
+		pinMode(_ym, OUTPUT);
+		*portOutputRegister(ym_port) &= ~ym_pin;
+	#endif
+	
    result = 1023-analogRead(_xm);
    
    //Clean pins for LCD fix
@@ -246,22 +279,36 @@ uint16_t TouchScreen::readTouchY(void) {
 
 
 uint16_t TouchScreen::pressure(void) {
-  // Set X+ to ground
-  pinMode(_xp, OUTPUT);
-  *portOutputRegister(xp_port) &= ~xp_pin;
-  //digitalWrite(_xp, LOW);
-  // Set Y- to VCC
-  pinMode(_ym, OUTPUT);
-  *portOutputRegister(ym_port) |= ym_pin;
-  //digitalWrite(_ym, HIGH); 
   
-  // Hi-Z X- and Y+
-  *portOutputRegister(xm_port) &= ~xm_pin;
-  //digitalWrite(_xm, LOW);
+  // Force LCD display pins for touchscreen operation
+  #if defined(__arm__)
+	// Set X+ to ground
+	pinMode(_xp, OUTPUT);
+	digitalWrite(_xp, LOW);
+	// Set Y- to VCC
+	pinMode(_ym, OUTPUT);
+	digitalWrite(_ym, HIGH); 
+  
+	// Hi-Z X- and Y+
+	digitalWrite(_xm, LOW);
+	digitalWrite(_yp, LOW);
+  #else
+	// Set X+ to ground
+	pinMode(_xp, OUTPUT);
+	*portOutputRegister(xp_port) &= ~xp_pin;
+	
+	// Set Y- to VCC
+	pinMode(_ym, OUTPUT);
+	*portOutputRegister(ym_port) |= ym_pin;
+	 
+	// Hi-Z X- and Y+
+	*portOutputRegister(xm_port) &= ~xm_pin;
+	*portOutputRegister(yp_port) &= ~yp_pin;
+	
+  #endif
+  
+  //Read settings
   pinMode(_xm, INPUT);
-  
-  *portOutputRegister(yp_port) &= ~yp_pin;
-  //digitalWrite(_yp, LOW);
   pinMode(_yp, INPUT);
   
   int16_t z1 = analogRead(_xm); 
@@ -296,7 +343,7 @@ bool TouchScreen::isTouching(void) {
 	//No need to clear pins, because pressure does it already
 	
 	//Minimum and maximum that we define as good touch
-	if (touch > 100 && touch < 980) {
+	if (touch > 20 && touch < 980) {
 		return true;
 	}
 	else return false;
@@ -304,16 +351,23 @@ bool TouchScreen::isTouching(void) {
 
 //Pin clearing function. This clears used pins for better LCD support on same pins.
 void TouchScreen::cleanPins(void) {
-	pinMode(_xm, OUTPUT);
-	*portOutputRegister(xm_port) &= ~xm_pin;
-	//digitalWrite(_xm, LOW);
-	pinMode(_yp, OUTPUT);
-	*portOutputRegister(yp_port) |= yp_pin;
-	//digitalWrite(_yp, HIGH);
-	pinMode(_ym, OUTPUT);
-	*portOutputRegister(ym_port) &= ~ym_pin;
-	//digitalWrite(_ym, LOW);
-	pinMode(_xp, OUTPUT);
-	*portOutputRegister(xp_port) |= xp_pin;
-	//digitalWrite(_xp, HIGH);
+	#if defined(__arm__)
+		pinMode(_xm, OUTPUT);
+		digitalWrite(_xm, LOW);
+		pinMode(_yp, OUTPUT);
+		digitalWrite(_yp, HIGH);
+		pinMode(_ym, OUTPUT);
+		digitalWrite(_ym, LOW);
+		pinMode(_xp, OUTPUT);
+		digitalWrite(_xp, HIGH);
+	#else
+		pinMode(_xm, OUTPUT);
+		*portOutputRegister(xm_port) &= ~xm_pin;
+		pinMode(_yp, OUTPUT);
+		*portOutputRegister(yp_port) |= yp_pin;
+		pinMode(_ym, OUTPUT);
+		*portOutputRegister(ym_port) &= ~ym_pin
+		pinMode(_xp, OUTPUT);
+		*portOutputRegister(xp_port) |= xp_pin;
+	#endif
 }

--- a/TouchScreen.cpp
+++ b/TouchScreen.cpp
@@ -293,8 +293,6 @@ bool TouchScreen::isTouching(void) {
 	//read current pressure level
 	uint16_t touch = pressure();
 	
-	Serial.print("Kosketus paine on: ");
-	Serial.print(touch);
 	//No need to clear pins, because pressure does it already
 	
 	//Minimum and maximum that we define as good touch

--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -25,14 +25,22 @@ class TouchScreen {
 
   bool isTouching(void);
   uint16_t pressure(void);
-  int readTouchY();
-  int readTouchX();
+  uint16_t readTouchY();
+  uint16_t readTouchX();
   TSPoint getPoint();
   int16_t pressureThreshhold;
 
 private:
+  //Input pins
   uint8_t _yp, _ym, _xm, _xp;
+  //Input pins port registers
+  uint8_t xp_port, yp_port, xm_port, ym_port;
+  //Input pins converted to mask
+  uint8_t xp_pin, yp_pin, xm_pin ,ym_pin;
+  
   uint16_t _rxplate;
+  //Internal cleanup function
+  void cleanPins(void);
 };
 
 #endif

--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -33,12 +33,15 @@ class TouchScreen {
 private:
   //Input pins
   uint8_t _yp, _ym, _xm, _xp;
-  //Input pins port registers
-  uint8_t xp_port, yp_port, xm_port, ym_port;
-  //Input pins converted to mask
-  uint8_t xp_pin, yp_pin, xm_pin ,ym_pin;
-  
-  uint16_t _rxplate;
+	#if defined(__arm__)
+	//No port manipulation in DUE and ARM boards
+	#elde
+		//Input pins port registers
+		uint8_t xp_port, yp_port, xm_port, ym_port;
+		//Input pins converted to mask
+		uint8_t xp_pin, yp_pin, xm_pin ,ym_pin;
+	#endif
+	uint16_t _rxplate;
   //Internal cleanup function
   void cleanPins(void);
 };


### PR DESCRIPTION
Added:
- isTouching() function atlast to the lib
- Internal cleanPins() function which is drived now every function that alters pins and there for now TouchScreen is pinsafe library atlast and supports LCD in same pins out of box.
- ARM support. Handling of commands with digitalWrite's instead of port handling

Speedup:
- Created private port, mask variables and moved their intializing to object creating functions. Now they use prosessor speed only when object is initialized, not every time when point is readed.
- Every write command are now direct port operations instead of digitalWrites.

Fixes:
- Library generally affected LCD pins everywhere. Because of this added internal cleanPins() funtion which is driven where needed in the lib.
- function pressure() was most badly affecting LCD pins, the cleanup code made it pinsafe and thus for were able to write simple isTouching() function without any cleanups.
- redefined int's and function definatios to more platform free int16_t's or uint16_t's