### PR TITLE
Create library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=Adafruit TouchScreen
+version=1.0.0
+author=Adafruit
+maintainer=Adafruit <info@adafruit.com>
+sentence=Adafruit TouchScreen display library.
+paragraph=Adafruit TouchScreen display library.
+category=Display
+url=https://github.com/adafruit/Touch-Screen-Library
+architectures=*


### PR DESCRIPTION
When using Eclipse CDT Arduino Plugin it doesn't pick up the library if the library.properties is not present. I thought I would share the one that I created incase it was useful. Not 100% sure about version, name or category but this is what I came up with. Feel free to accept or close as you see fit.